### PR TITLE
Restrict Feliz.CompilerPlugins version required by Feliz 1

### DIFF
--- a/Feliz/Feliz.fsproj
+++ b/Feliz/Feliz.fsproj
@@ -38,7 +38,21 @@
     <Compile Include="ReactDOM.fs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Feliz.CompilerPlugins\Feliz.CompilerPlugins.fsproj" />
+    <ProjectReference Include="..\Feliz.CompilerPlugins\Feliz.CompilerPlugins.fsproj" PackageVersion="[1.1.0, 2.0.0)"/>
   </ItemGroup>
+    <Target Name="UseExplicitPackageVersions" BeforeTargets="GenerateNuspec">
+    <ItemGroup>
+      <_ProjectReferenceWithExplicitPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.PackageVersion)' != ''" />
+      <_ProjectReferenceWithExactPackageVersion Include="@(ProjectReference->'%(FullPath)')" Condition="'%(ProjectReference.ExactVersion)' == 'true'" />
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExplicitPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>@(_ProjectReferenceWithExplicitPackageVersion->'%(PackageVersion)')</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferenceWithReassignedVersion Include="@(_ProjectReferencesWithVersions)" Condition="'%(Identity)' != '' And '@(_ProjectReferenceWithExactPackageVersion)' == '@(_ProjectReferencesWithVersions)'">
+        <ProjectVersion>[@(_ProjectReferencesWithVersions->'%(ProjectVersion)')]</ProjectVersion>
+      </_ProjectReferenceWithReassignedVersion>
+      <_ProjectReferencesWithVersions Remove="@(_ProjectReferenceWithReassignedVersion)" />
+      <_ProjectReferencesWithVersions Include="@(_ProjectReferenceWithReassignedVersion)" />
+    </ItemGroup>
+  </Target>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Hello @Zaid-Ajaj,

**Important:** This PR is not to be merged into master but should instead go into a feliz1 branch. In theory, I created this branch on the latest commit related to v1.

This branch is related to #544. The goal of this branch is to push a new version of Feliz 1 which restrict Feliz.CompilerPlugin to version 1 only.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/4760796/219955213-85804697-52ee-42a9-8f87-993558aef94d.png">

I had to use a custom MSBuild task because MSBuild doesn't support version restriction on `ProjectReference` out of the box.

https://github.com/NuGet/Home/issues/5556#issuecomment-1179526189

