### PR TITLE
Update docs link in README.md to fable-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ npm start
 
 ### Documentation
 
-Feliz has extensive documentation at [https://zaid-ajaj.github.io/Feliz](https://zaid-ajaj.github.io/Feliz) with live examples along side code samples, check them out and if you have any question, let us know!
+Feliz has extensive documentation at [https://fable-hub.github.io/Feliz/](https://fable-hub.github.io/Feliz/) with live examples along side code samples, check them out and if you have any question, let us know!


### PR DESCRIPTION
The organisation has changed from Zaid-Ajaj to fable-hub, so the GitHub pages link is broken. The correct link seems to be  https://fable-hub.github.io/Feliz/

The same change is also needed in the Repository's About website setting