### PR TITLE
Custom react memo equality function

### DIFF
--- a/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
+++ b/Feliz.CompilerPlugins/Feliz.CompilerPlugins.fsproj
@@ -8,6 +8,7 @@
     <PackageReleaseNotes>Remove redundant declaration of imported React component</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="StringSyntax.fs" />
     <Compile Include="AstUtils.fs" />
     <Compile Include="ReactComponent.fs" />
     <Compile Include="Hook.fs" />

--- a/Feliz.CompilerPlugins/StringSyntax.fs
+++ b/Feliz.CompilerPlugins/StringSyntax.fs
@@ -1,0 +1,32 @@
+﻿#if !NET7_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+
+open System
+
+/// <summary>Specifies the syntax used in a string.</summary>
+[<AttributeUsage(AttributeTargets.Parameter ||| AttributeTargets.Field ||| AttributeTargets.Property, AllowMultiple = false, Inherited = false)>]
+type internal StringSyntaxAttribute
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringSyntaxAttribute"/> class with the identifier of the syntax used.
+    /// </summary>
+    /// <param name="syntax">The syntax identifier.</param>
+    /// <param name="arguments">Optional arguments associated with the specific syntax employed.</param>
+    (syntax: string, [<ParamArray>] arguments: obj[]) =
+
+    inherit Attribute()
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringSyntaxAttribute"/> class with the identifier of the syntax used.
+    /// </summary>
+    /// <param name="syntax">The syntax identifier.</param>
+    new (syntax: string) = StringSyntaxAttribute(syntax, [||])
+
+    /// <summary>Gets the identifier of the syntax used.</summary>
+    member val public Syntax = syntax with get
+
+    /// <summary>Gets optional arguments associated with the specific syntax employed.</summary>
+    member val public Arguments = arguments with get
+
+#endif


### PR DESCRIPTION
Hi folks!

We've needed this functionality quite bad for some performance critical parts of the app. The workaround we've used initially was resorting to the old `FunctionComponent.Of` api. However the main drawback of this approach is broken hmr: 

`FunctionComponent.Of` both defines a function component as well as declares the React element via `react.createElement`.

That was one of the primary reasons why `[<ReactComponent>]` is now the preferred approach of defining react components - attribute plugin acts as a glue between component definition (declares function component) and the call site (creates one within the parent via react.createElement api). 

In case of memoized components, the component definition must be a named function (not lambda), that is wrapped in memo - `const component = memo(function MyComponent { ... })`. `memo` also allows to pass a custom equality function.

ReactComponent memo functionality was extended to:
* Allow default shallow object comparison (call to memo without equality function)
* Allow `equalsButFunctions` function that was initially introduced in Fable.Elmish - it uses the equality from fable js library, but ignores the function fields.
* Allow custom js function passed to the attribute, - it is highlighted as `[<StringSyntax("javascript")>] and allows either inlined function declaration or usage of function imported/declared within file.

Additionally, I've added the aliases to the ReactComponentAttribute* family, so that consumers could use this syntax:
```
[<ReactComponent>]
[<ReactComponent.Memo>]
[<ReactComponent.Memo.EqualsButFunctions>]
[<ReactComponent.Memo "(x, y) => {
    const value = custom(x, y);
    return value || x === y;
}">]
```

Below you can see the examples usages:

## Simple component



```fsharp
[<ReactComponent>]
let Anonymous(props: {|
    value: string
|}) =
    Html.span [ prop.text props.value ]
```

```javascript
export function Anonymous(props) {
    return createElement("span", {
        children: props.value,
    });
}
```

## Memo component

```fsharp
[<ReactComponent.Memo>]
let Memo(props: Example) =
    React.fragment [
        Html.span [ prop.text props.value ]
        Html.button [ prop.text "+"; prop.onClick (fun _ -> props.setValue (props.value + 1)) ]
    ]
```

```javascript
export function Anonymous(props) {
    return createElement("span", {
        children: props.value,
    });
}
```

## Memo.EqualsButFunctions component

```fsharp
[<ReactComponent.Memo.EqualsButFunctions>]
let MemoEqualsButFunctions(props: Example) =
    React.fragment [
        Html.span [ prop.text props.value ]
        Html.button [ prop.text "+"; prop.onClick (fun _ -> props.setValue (props.value + 1)) ]
    ]
```

**Notes** 
* MemoEqualsButFunctions requires `equals` from npm installed `@fable-org/fable-library-js` within the project.

* The `function MemoEqualsButFunctions(props) {  ((props) => {...})(props); }` - named function is required for memo to know the name of the component (otherwise it will be `Anonymous`). As Expr.Delegate is translated by Fable to the lambda - we emit the named function with self executing lambda.



```javascript
export const MemoEqualsButFunctions = memo(
  function MemoEqualsButFunctions(props) {
    return ((props) => {
      const xs_2 = [
        createElement("span", {
          children: props.value,
        }),
        createElement("button", {
          children: "+",
          onClick: (_arg) => {
            props.setValue(props.value + 1);
          },
        }),
      ];
      return react.createElement(react.Fragment, {}, ...xs_2);
    })(props);
  },
  function equalsButFunctions(x, y) {
    if (x === y) {
      return true;
    } else if (typeof x === "object" && !x[Symbol.iterator] && !(y == null)) {
      const keys = Object.keys(x);
      const length = keys.length | 0;
      let i = 0;
      let result = true;
      while (i < length && result) {
        const key = keys[i];
        i = (i + 1) | 0;
        const xValue = x[key];
        result = typeof xValue === "function" ? true : equals(xValue, y[key]);
      }
      return result;
    } else {
      return equals(x, y);
    }
  }
);
```

## Memo custom equality component

```fsharp
let [<Literal>] CUSTOM_EXAMPLE_EQUALITY = "myCustomEquals"
let [<CompiledName(CUSTOM_EXAMPLE_EQUALITY)>] private exampleEq (x: Example, y: Example) =
    x.value = y.value
[<ReactComponent.Memo(CUSTOM_EXAMPLE_EQUALITY)>]
let MemoEquals(props: Example) =
    React.fragment [
        Html.span [ prop.text props.value ]
        Html.button [ prop.text "+"; prop.onClick (fun _ -> props.setValue (props.value + 1)) ]
    ]
```

```javascript
function myCustomEquals(x, y) {
  return x.value === y.value;
}

export const MemoEquals = memo(function MemoEquals(props) {
  return ((props) => {
    const xs_2 = [
      createElement("span", {
        children: props.value,
      }),
      createElement("button", {
        children: "+",
        onClick: (_arg) => {
          props.setValue(props.value + 1);
        },
      }),
    ];
    return react.createElement(react.Fragment, {}, ...xs_2);
  })(props);
}, myCustomEquals);

```

## Memo imported custom equality component

![Image](https://github.com/user-attachments/assets/1f2622ce-c538-4af2-bf6f-c01550be17f6)

```javascript
import { custom } from "@my/lib";

export const MemoEqualsImported = memo(
  function MemoEqualsImported(props) {
    return ((props) => {
      const xs_1 = [
        props.value,
        createElement("button", {
          children: "+",
          onClick: (_arg) => {
            props.setValue(props.value + 1);
          },
        }),
      ];
      return react.createElement(react.Fragment, {}, ...xs_1);
    })(props);
  },
  (x, y) => {
    const value = custom(x, y);
    return value || x === y;
  }
);

```